### PR TITLE
fix issue#39

### DIFF
--- a/gui/src/views/tabs/Finder.vue
+++ b/gui/src/views/tabs/Finder.vue
@@ -159,6 +159,12 @@ export default {
           root: this.root,
         })
         this.list = list
+        if(this.list.length === 0 && path === 'Library/Caches/Snapshots') {
+          this.$toast.open({
+          message: `Operation not permitted`,
+          type: 'is-danger',
+          })
+        }
       } catch(ex) {
         this.$toast.open({
           message: `failed to change current directory: ${ex}`,


### PR DESCRIPTION
Toast 'Operation not permitted' message when view  Library/Caches/Snapshots directory in high version system.